### PR TITLE
fix warnings: jsx attr names; deprecated mixin pattern

### DIFF
--- a/js/components/submit_form.react.js
+++ b/js/components/submit_form.react.js
@@ -1,8 +1,11 @@
 import React from 'react';
+import Router from 'react-router';
 import Actions from '../actions/actions';
 
 var SubmitForm = React.createClass({
-  mixins: [Router.Navigation],
+  contextTypes: {
+    router: React.PropTypes.func.isRequired
+  },
 
   getInitialState: function() {
     return {
@@ -19,15 +22,15 @@ var SubmitForm = React.createClass({
     return (
       <div>
         <h1>hi i am a submit form!</h1>
-        <div class="input-url">
-          <label for="url">url</label>
+        <div className="input-url">
+          <label htmlFor="url">url</label>
           <input type="text" name="url" value={this.state.post.url} onChange={this._handleChange}/>
         </div>
-        <div class="input-title">
-          <label for="title">title</label>
+        <div className="input-title">
+          <label htmlFor="title">title</label>
           <input type="text" name="title" value={this.state.post.title} onChange={this._handleChange}/>
         </div>
-        <div class="submit">
+        <div className="submit">
           <button onClick={this._handleLinkSubmission}>submit</button>
         </div>
       </div>
@@ -36,7 +39,7 @@ var SubmitForm = React.createClass({
 
   _handleLinkSubmission: function() {
     Actions.createPost(this.state.post);
-    this.transitionTo('/');
+    this.context.router.transitionTo('/');
   },
 
   _handleChange: function(event) {


### PR DESCRIPTION
- `className` instead of `class`, `htmlFor` instead of `for` (these appear to be the only attributes named differently than the norm)
- mixins and `this.transitionTo()` is deprecated; instead, we're supposed to use `this.context`.. I guess as long as you declare `router` in a component's `contextTypes`, react-router automatically attaches itself as `this.context.router`
